### PR TITLE
Update Business:ISBN dependency

### DIFF
--- a/META.json
+++ b/META.json
@@ -37,7 +37,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Business::ISBN" : "2.09",
+            "Business::ISBN" : "2.010",
             "Business::ISSN" : "0.91",
             "Catmandu" : "0.94",
             "Data::UUID" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -12,7 +12,7 @@ on 'test', sub {
 
 requires 'Catmandu', '>=0.94';
 requires 'Business::ISSN', '0.91';
-requires 'Business::ISBN', '2.09';
+requires 'Business::ISBN', '2.010';
 requires 'Data::UUID',0;
 requires 'LWP::Simple',0;
 requires 'WWW::ORCID',0;


### PR DESCRIPTION
I had to reindex to get three digit minor versions,
so 2.09 and 2.010 sorted the wrong way
